### PR TITLE
Add CI, NOTICE and replace License header

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,85 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - dev
+      - main
+    tags:
+  pull_request:
+  release:
+
+jobs:
+  check-copyright:
+    name: Copyright
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: License header
+        run: .scripts/check-copyright-notice.sh
+      - name: Authors
+        run: .scripts/check-notice-authors.sh origin/main
+
+  lint:
+    name: GolangCI-Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Check vanity import
+        run: .scripts/check-vanity-imports.sh $GITHUB_WORKSPACE
+      - name: Lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          version: v1.43
+
+  tests:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.17
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Unit Tests
+        run: go test -timeout 60s ./...
+
+  race-tests:
+    name: Race Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Golang
+        uses: actions/setup-go@v2
+        with:
+          go-version: ^1.17
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-race
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Unit Race Tests
+        run: go test -timeout 120s -race ./...

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           path: |
             ~/.cache/go-build
             ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}-race
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
           restore-keys: |
             ${{ runner.os }}-go-
 

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,95 @@
+run:
+  timeout: 2m
+
+  # Do not change go.{mod,sum}.
+  modules-download-mode: readonly
+
+linters:
+  enable:
+    - bodyclose
+    - deadcode
+    - depguard
+    - dogsled
+    - dupl
+    - errcheck
+    - exportloopref
+    - funlen
+    # We use init() functions.
+    #- gochecknoinits
+    - goconst
+    - gocritic
+    - gocyclo
+    - gofmt
+    - goimports
+    # This is stupid since it reports every constant as magic-number.
+    #- gomnd
+    - goprintffuncname
+    - gosec
+    - gosimple
+    - govet
+    - ineffassign
+    # This thing reports long lines, but we have a lot of them…
+    #- lll
+    - misspell
+    # We often just have a 'return' when using named returns.
+    #- nakedret
+    - nolintlint
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - whitespace
+    - asciicheck
+    # We often use globals for backend stuff
+    #- gochecknoglobals
+    - gocognit
+    - godot
+    # Reports TODO/BUG/FIXME
+    #- godox
+    # Keeps reporting 'do not define dynamic errors, use wrapped static errors instead'.
+    #- goerr113
+    # We don't care about alignment right now.
+    #- maligned
+    - nestif
+    - prealloc
+    # This always reports that tests should be Black Box.
+    #- testpackage
+    #- wsl
+
+issues:
+  exclude-rules:
+    - path: test
+      linters:
+        # 'Error return value … not checked'
+        - errcheck 
+        - funlen
+        # Tests do not need to prealloc everything.
+        - prealloc
+    # `Id` instead of `ID` is fine in tests.
+    - path: test
+      text: " should be "
+      linters:
+        - golint
+        - stylecheck
+    # Allow nil contexts in tests.
+    - path: test
+      text: "SA1012"
+      linters:
+        - staticcheck
+    # Allow unchecked errors in tests.
+    - path: test
+      text: "G104"
+      linters:
+        - gosec
+
+    # Exclude lll issues for long lines with go:generate.
+    - linters:
+        - lll
+      source: "^//go:generate "
+
+  exclude-use-default: false

--- a/.scripts/check-copyright-notice.sh
+++ b/.scripts/check-copyright-notice.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: Apache-2.0
+
 cn="$(dirname $(readlink -f $0))/copyright-notice"
 n=$(wc -l $cn | cut -d ' ' -f 1)
 

--- a/.scripts/check-copyright-notice.sh
+++ b/.scripts/check-copyright-notice.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+cn="$(dirname $(readlink -f $0))/copyright-notice"
+n=$(wc -l $cn | cut -d ' ' -f 1)
+
+function check_cr() {
+  diff $cn <(head -n${n} $1 | sed -e 's/20\(19\|2[0-9]\)/20XX/') -q > /dev/null
+  if [ $? -ne 0 ]; then
+    echo $1
+    diff $cn <(head -n${n} $1)
+  fi
+}
+
+if [ $# -ne 0 ]; then
+  code=0
+  for f in "$@"; do
+    check_cr $f
+    [ $? -ne 0 ] && code=1
+  done
+  exit $code
+fi
+
+find . -name "*.go" -exec $0 {} +

--- a/.scripts/check-notice-authors.sh
+++ b/.scripts/check-notice-authors.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+
+set -e
+exit_code=0
+
+# This script checks that all new commiters email adresses are contained in the NOTICE
+# file.
+# To check all commits on the current branch:       ./check-notice-authors.sh
+# To check all commits newer than the last merge:   ./check-notice-authors.sh $(git log --pretty=format:"%H" --merges -n 1)
+
+# Call with an ancestor whereas all commits newer than the ancestor are checked.
+base="$1"
+if [ -z "$base" ]; then
+    commits="$(git rev-list --no-merges --reverse HEAD)"
+else
+    commits="$(git rev-list --no-merges --reverse $base..HEAD)"
+fi
+
+echo "Current commit: $(git rev-parse HEAD)"
+# Authors found in commits and NOTICE.
+declare -A known_authors
+# Authors found only in commits but not NOTICE file.
+declare -A assumed_authors
+
+for c in $commits; do
+    echo "Checking commit: $c"
+    author=$(git show -s --format='%an <%ae>' $c)
+    # Check Signed-Off-By message
+    if ! git show -s --format='%B' $c | grep -wq "Signed-off-by: $author"; then
+        echo "Commit $c is missing or has wrong 'Signed-off-by' message."
+        exit_code=1
+    fi
+
+    # Get the notice file of the commit and check that the author is in it.
+    notice=$(git show $c:NOTICE 2> /dev/null || true)
+    for k in "${known_authors[@]}"; do
+        a="${known_authors[$k]}"
+        if ! echo "$notice" | grep -wq "$a"; then
+            echo "Author '$a' was deleted from NOTICE in commit $c"
+            exit_code=1
+        fi
+    done
+    if [ -n "${assumed_authors[$author]}" ]; then
+        continue
+    fi
+    # This must be the first commit of this author, since he should add himself
+    # to the NOTICE file here.
+    if ! echo "$notice" | grep -wq "$author"; then
+        echo "Author '$author' is missing from NOTICE file and should have been added in commit $c."
+        assumed_authors[$author]="$author"
+        unset "known_authors[$author]"
+        exit_code=1
+    else
+        known_authors[$author]="$author"
+        unset "assumed_authors[$author]"
+    fi
+done
+
+exit $exit_code

--- a/.scripts/check-vanity-imports.sh
+++ b/.scripts/check-vanity-imports.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+ERR=0
+
+# Call with working directory, eg: .scripts/check-vanity-imports.sh $PWD
+[ "$#" -ne 1 ] && (echo "Need working directory as first argument" && exit 1)
+
+# Loop over all subdirectories not starting with a . and alias them $pkg.
+for pkg in $(find $1 -mindepth 1 -type d ! -path '*/\.*'); do
+	# Count the vanity imports in the $pkg folder.
+	numImports="$(find $pkg -maxdepth 1 -type f -name '*.go' -print0 | xargs -0 egrep -ho '^package [a-z0-9_]+ // import ".*$' | wc -l)"
+	# Count how many non _test package definitions (eg. package my_test) the $pkg folder contains.
+	numNonTestPackages="$(find $pkg -maxdepth 1 -type f -name '*.go' -print0 | xargs -0 egrep -ho '^package [a-z0-9_]+' | egrep -v '_test' | wc -l)"
+
+	# _test packages are allowed to not have a vanity import path.
+	# So if the directory contains a non-_test package, there must be an import path.
+	if [ $numImports -eq 0 ] && [ $numNonTestPackages -gt 0 ]; then
+		echo "Package is missing vanity import path: $pkg"
+		ERR=1
+	# Here we check that the whole folder does not have more than one vanity
+	# import. This implies that _test packages do not have import paths when
+	# they are in the same folder as a non _test package.
+	elif [ $numImports -gt 1 ]; then
+		echo "Package has more than one vanity import path: $pkg"
+		ERR=1
+	fi
+done
+
+exit $ERR

--- a/.scripts/check-vanity-imports.sh
+++ b/.scripts/check-vanity-imports.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+# SPDX-License-Identifier: Apache-2.0
+
 ERR=0
 
 # Call with working directory, eg: .scripts/check-vanity-imports.sh $PWD

--- a/.scripts/copyright-notice
+++ b/.scripts/copyright-notice
@@ -1,0 +1,1 @@
+// SPDX-License-Identifier: Apache-2.0

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,41 @@
+# This is the official list of Perun Network go-perun copyright
+# holders and authors.
+#
+# Often employers or academic institutions have ownership over code that is
+# written in certain circumstances, so please do due diligence to ensure that
+# you have the right to submit the code.
+#
+# When adding J Random Contributor's name to this file, either J's name on its
+# own or J's name associated with J's organization's name should be added,
+# depending on whether J's employer (or academic institution) has ownership
+# over code that is written for this project.
+#
+# How to add names to this file:
+#     Individual's name <submission email address>.
+#
+# If Individual's organization is copyright holder of her contributions add the
+# organization's name, optionally also the contributor's name:
+#
+#     Organization's name
+#         Individual's name <submission corporate email address>
+#
+# Please keep the list in alphabetical order.
+
+Chair of Applied Cryptography, Technische Universität Darmstadt, Germany
+	Christoph Conrads <christoph@perun.network>
+	Norbert Dzikowski <norbert@perun.network>
+	Matthias Geihs <matthias@perun.network>
+	Steffen Rattay <steffen@perun.network>
+	Sebastian Stammler <seb@perun.network>
+	Oliver Tale-Yazdi <oliver@perun.network>
+	Marius van der Wijden <marius@perun.network>
+
+PolyCrypt GmbH
+	Norbert Dzikowski <norbert@perun.network>
+	Matthias Geihs <matthias@perun.network>
+	Steffen Rattay <steffen@perun.network>
+	Sebastian Stammler <seb@perun.network>
+	Oliver Tale-Yazdi <oliver@perun.network>
+
+Robert Bosch GmbH
+	Manoranjith <ponraj.manoranjitha@in.bosch.com>

--- a/context/context.go
+++ b/context/context.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package context contains helper utilities regarding go contexts.
 package context // import "polycry.pt/poly-go/context"

--- a/context/context_test.go
+++ b/context/context_test.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package context_test
 

--- a/context/terminates.go
+++ b/context/terminates.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package context
 

--- a/context/terminates_test.go
+++ b/context/terminates_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package context
 

--- a/context/test/terminates.go
+++ b/context/test/terminates.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package test tests the helper utilities regarding go contexts.
 package test // import "polycry.pt/poly-go/context/test"

--- a/context/test/terminates_test.go
+++ b/context/test/terminates_test.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/errors/doc.go
+++ b/errors/doc.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package errors contains functionality for simplifying and improving error
 // handling.

--- a/errors/gatherer.go
+++ b/errors/gatherer.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package errors
 

--- a/errors/gatherer_test.go
+++ b/errors/gatherer_test.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package errors_test
 

--- a/io/bigint.go
+++ b/io/bigint.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io
 

--- a/io/bigint_external_test.go
+++ b/io/bigint_external_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io_test
 

--- a/io/byteslice.go
+++ b/io/byteslice.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io
 

--- a/io/byteslice_external_test.go
+++ b/io/byteslice_external_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io_test
 

--- a/io/doc.go
+++ b/io/doc.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package io contains functionality for the serialization of standard Go types.
 package io // import "polycry.pt/poly-go/io"

--- a/io/equal_encoding.go
+++ b/io/equal_encoding.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io
 

--- a/io/equal_encoding_external_test.go
+++ b/io/equal_encoding_external_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io_test
 

--- a/io/serialize.go
+++ b/io/serialize.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io
 

--- a/io/serializer.go
+++ b/io/serializer.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io
 

--- a/io/string.go
+++ b/io/string.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io
 

--- a/io/string_test.go
+++ b/io/string_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io
 

--- a/io/test/serializertest.go
+++ b/io/test/serializertest.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package test contains the generic serializer tests.
 package test // import "polycry.pt/poly-go/io/test"

--- a/io/wire_test.go
+++ b/io/wire_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package io
 

--- a/math/big/doc.go
+++ b/math/big/doc.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package big contains helpers for package math/big.
 package big // import "polycry.pt/poly-go/math/big"

--- a/math/big/summer.go
+++ b/math/big/summer.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package big
 

--- a/math/big/summer_external_test.go
+++ b/math/big/summer_external_test.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package big_test
 

--- a/sortedkv/batch.go
+++ b/sortedkv/batch.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sortedkv
 

--- a/sortedkv/database.go
+++ b/sortedkv/database.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package sortedkv defines a sorted key-value store abstraction. It is used by
 // other persistence packages (like channel/persistence) to continuously save

--- a/sortedkv/iterator.go
+++ b/sortedkv/iterator.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sortedkv
 

--- a/sortedkv/key/key.go
+++ b/sortedkv/key/key.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package key of sortedkv provides helper functions to manipulate db keys
 package key // import "polycry.pt/poly-go/sortedkv/key"

--- a/sortedkv/key/key_test.go
+++ b/sortedkv/key/key_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package key_test
 

--- a/sortedkv/leveldb/batch.go
+++ b/sortedkv/leveldb/batch.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package leveldb
 

--- a/sortedkv/leveldb/database.go
+++ b/sortedkv/leveldb/database.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package leveldb
 

--- a/sortedkv/leveldb/doc.go
+++ b/sortedkv/leveldb/doc.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package leveldb implements the key-value database interface using LevelDB.
 package leveldb // import "polycry.pt/poly-go/sortedkv/leveldb"

--- a/sortedkv/leveldb/iterator.go
+++ b/sortedkv/leveldb/iterator.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package leveldb
 

--- a/sortedkv/leveldb/leveldb_test.go
+++ b/sortedkv/leveldb/leveldb_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package leveldb
 

--- a/sortedkv/memorydb/batch.go
+++ b/sortedkv/memorydb/batch.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package memorydb
 

--- a/sortedkv/memorydb/batch_test.go
+++ b/sortedkv/memorydb/batch_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package memorydb
 

--- a/sortedkv/memorydb/database.go
+++ b/sortedkv/memorydb/database.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package memorydb provides an implementation of the sortedkv interfaces. The main
 // type, Database, is an in-memory key-value store. Since the database is not

--- a/sortedkv/memorydb/database_test.go
+++ b/sortedkv/memorydb/database_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package memorydb
 

--- a/sortedkv/memorydb/iterator.go
+++ b/sortedkv/memorydb/iterator.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package memorydb
 

--- a/sortedkv/memorydb/iterator_test.go
+++ b/sortedkv/memorydb/iterator_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package memorydb
 

--- a/sortedkv/table.go
+++ b/sortedkv/table.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sortedkv
 

--- a/sortedkv/tablebatch.go
+++ b/sortedkv/tablebatch.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sortedkv
 

--- a/sortedkv/tableiterator.go
+++ b/sortedkv/tableiterator.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sortedkv
 

--- a/sortedkv/test/batchtest.go
+++ b/sortedkv/test/batchtest.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/sortedkv/test/databasetest.go
+++ b/sortedkv/test/databasetest.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package test implements a generic test for all implementations of the
 // Database interface.

--- a/sortedkv/test/iteratortest.go
+++ b/sortedkv/test/iteratortest.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/sortedkv/test/tabletest.go
+++ b/sortedkv/test/tabletest.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/sync/atomic/bool.go
+++ b/sync/atomic/bool.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package atomic contains extensions of "sync/atomic"
 package atomic // import "polycry.pt/poly-go/sync/atomic"

--- a/sync/atomic/bool_test.go
+++ b/sync/atomic/bool_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package atomic_test
 

--- a/sync/closer.go
+++ b/sync/closer.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sync
 

--- a/sync/closer_internal_test.go
+++ b/sync/closer_internal_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sync
 

--- a/sync/closer_test.go
+++ b/sync/closer_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sync_test
 

--- a/sync/mutex.go
+++ b/sync/mutex.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package sync contains a mutex that can be used in a select statement.
 package sync // import "polycry.pt/poly-go/sync"

--- a/sync/mutex_test.go
+++ b/sync/mutex_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sync
 

--- a/sync/signal.go
+++ b/sync/signal.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sync
 

--- a/sync/signal_test.go
+++ b/sync/signal_test.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sync_test
 

--- a/sync/waitgroup.go
+++ b/sync/waitgroup.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sync
 

--- a/sync/waitgroup_test.go
+++ b/sync/waitgroup_test.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package sync_test
 

--- a/test/cloning.go
+++ b/test/cloning.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/cloning_test.go
+++ b/test/cloning_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/concurrent.go
+++ b/test/concurrent.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/concurrent_external_test.go
+++ b/test/concurrent_external_test.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test_test
 

--- a/test/concurrent_test.go
+++ b/test/concurrent_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/doc.go
+++ b/test/doc.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package test contains testing utilities.
 package test // import "polycry.pt/poly-go/test"

--- a/test/eventually.go
+++ b/test/eventually.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/eventually_test.go
+++ b/test/eventually_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/exit.go
+++ b/test/exit.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/exit_test.go
+++ b/test/exit_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/goexit.go
+++ b/test/goexit.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/goexit_test.go
+++ b/test/goexit_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/onlyonce.go
+++ b/test/onlyonce.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/onlyonce_test.go
+++ b/test/onlyonce_test.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/panic.go
+++ b/test/panic.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 // Package test contains helper functions for testing.
 package test

--- a/test/panic_test.go
+++ b/test/panic_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/prng.go
+++ b/test/prng.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/prng_test.go
+++ b/test/prng_test.go
@@ -1,16 +1,4 @@
-// Copyright 2020 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/testmock.go
+++ b/test/testmock.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/testmock_test.go
+++ b/test/testmock_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/wrapmock.go
+++ b/test/wrapmock.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 

--- a/test/wrapmock_test.go
+++ b/test/wrapmock_test.go
@@ -1,16 +1,4 @@
-// Copyright 2019 - See NOTICE file for copyright holders.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
+// SPDX-License-Identifier: Apache-2.0
 
 package test
 


### PR DESCRIPTION
- Create a `NOTICE` file
- Copy the CI configs from `go-perun`
- Use `SPDX` as license header  

Relates to #8 