### PR TITLE
random: Add random package and String implementation

### DIFF
--- a/random/doc.go
+++ b/random/doc.go
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: Apache-2.0
+
+// Package random contains random generator utilities for primitives and types.
+package random // import "polycry.pt/poly-go/random"

--- a/random/string.go
+++ b/random/string.go
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+package random
+
+import (
+	"math/rand"
+)
+
+var runes = []rune("abcdefghijklmnopABCDEFGHIJKLMNOP0123456789 ")
+
+// String returns a random string of the given size with potentially lower and
+// uppercase letters as well as intermingled numbers and spaces.
+func String(rng *rand.Rand, size int) string {
+	s := make([]rune, size)
+	for i := range s {
+		s[i] = runes[rng.Int()%len(runes)]
+	}
+	return string(s)
+}


### PR DESCRIPTION
I propose to add a `random` or `test/random` package which contains utility implementations for various allround random generators like `string`s.

Usage: `random.NewString(rng, arg1, arg2)`