### PR TITLE
Fix race in Gatherer.Add()

### DIFF
--- a/errors/gatherer.go
+++ b/errors/gatherer.go
@@ -65,15 +65,15 @@ func (g *Gatherer) Add(err error) {
 
 	g.mutex.Lock()
 	g.errs = append(g.errs, err)
-	g.mutex.Unlock()
 
 	select {
 	case <-g.failed:
+		g.mutex.Unlock()
 		return
 	default:
+		close(g.failed)
+		g.mutex.Unlock()
 	}
-
-	close(g.failed)
 
 	for _, fn := range g.onFails {
 		fn()


### PR DESCRIPTION
Previously, multiple concurrent failures on a previously empty Gatherer
could result in a duplicate channel closure and a resulting panic.

Signed-off-by: Steffen Rattay <steffen@perun.network>