### PR TITLE
test: Add NameStr string wrapper

### DIFF
--- a/test/prng.go
+++ b/test/prng.go
@@ -65,3 +65,10 @@ func Seed(seed string, args ...interface{}) int64 {
 	}
 	return int64(hasher.Sum64())
 }
+
+// NameStr endows a string with a function `Name() string` that returns itself.
+// This is helpful for using strings as a first argument to `Prng`.
+type NameStr string
+
+// Name returns the string underlying NameStr.
+func (s NameStr) Name() string { return string(s) }


### PR DESCRIPTION
`Prng` was designed to receive instances of `*testing.T`, which have a
function `Name() string`. `NameStr` can now be used to use strings as the
first argument to `Prng`, because it gives a string a `Name() string`
function.
